### PR TITLE
Fixing data race condition due to stream access overload

### DIFF
--- a/manipulator_gym/interfaces/base_interface.py
+++ b/manipulator_gym/interfaces/base_interface.py
@@ -32,7 +32,7 @@ class ManipulatorInterface(ABC):
     @property
     def primary_img(self) -> np.ndarray:
         """return the image from the camera"""
-        return self.primary_frame
+        return self._primary_frame
 
     @property
     def wrist_img(self) -> Optional[np.ndarray]:
@@ -40,7 +40,7 @@ class ManipulatorInterface(ABC):
         return the image from the wrist camera
         default is None (no wrist camera)
         """
-        return np.zeros((256, 256, 3), dtype=np.uint8)
+        return self._wrist_frame
 
     @property
     def joint_states(self) -> Optional[np.ndarray]:
@@ -99,14 +99,17 @@ class ManipulatorInterface(ABC):
         return True
 
     def fetch_primary_img(self) -> None:
-        self.primary_frame = np.zeros((256, 256, 3), dtype=np.uint8)
+        self._primary_frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    
+    def fetch_wrist_img(self) -> None:
+        self._wrist_frame = np.zeros((256, 256, 3), dtype=np.uint8)
 
     def _run_continuous_img_fetch(self):
         """Continuously run img fetching in a loop."""
         while True:
             try:
                 _ = self.fetch_primary_img()
-                _ = self.wrist_img
+                _ = self.fetch_wrist_img()
             except Exception as e:
                 print(f"Error in continuous img thread: {e}")
                 break

--- a/manipulator_gym/interfaces/base_interface.py
+++ b/manipulator_gym/interfaces/base_interface.py
@@ -32,7 +32,7 @@ class ManipulatorInterface(ABC):
     @property
     def primary_img(self) -> np.ndarray:
         """return the image from the camera"""
-        return np.zeros((256, 256, 3), dtype=np.uint8)
+        return self.primary_frame
 
     @property
     def wrist_img(self) -> Optional[np.ndarray]:
@@ -98,11 +98,14 @@ class ManipulatorInterface(ABC):
         """Interface to implement any runtime configuration"""
         return True
 
+    def fetch_primary_img(self) -> None:
+        self.primary_frame = np.zeros((256, 256, 3), dtype=np.uint8)
+
     def _run_continuous_img_fetch(self):
         """Continuously run img fetching in a loop."""
         while True:
             try:
-                _ = self.primary_img
+                _ = self.fetch_primary_img()
                 _ = self.wrist_img
             except Exception as e:
                 print(f"Error in continuous img thread: {e}")

--- a/manipulator_gym/interfaces/base_interface.py
+++ b/manipulator_gym/interfaces/base_interface.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import numpy as np
 import time
+import threading
 from typing import Optional, Dict
 from abc import ABC, abstractmethod
 
@@ -96,3 +97,25 @@ class ManipulatorInterface(ABC):
     def configure(self, **kwargs) -> bool:
         """Interface to implement any runtime configuration"""
         return True
+
+    def _run_continuous_img_fetch(self):
+        """Continuously run img fetching in a loop."""
+        while True:
+            try:
+                _ = self.primary_img
+                _ = self.wrist_img
+            except Exception as e:
+                print(f"Error in continuous img thread: {e}")
+                break
+
+    def start_img_fetch_thread(self):
+        """Start a thread that continuously runs img fetching."""
+        self.img_thread = threading.Thread(
+            target=self._run_continuous_img_fetch,
+            daemon=True  # This ensures the thread will be terminated when the main program exits
+        )
+        self.img_thread.start()
+        return self.img_thread
+    
+    def __exit__(self):
+        self.img_thread.exit()

--- a/manipulator_gym/interfaces/viperx.py
+++ b/manipulator_gym/interfaces/viperx.py
@@ -18,7 +18,6 @@ np.set_printoptions(precision=3, suppress=True)
 
 ##############################################################################
 
-
 class ViperXInterface(ManipulatorInterface):
     """
     https://github.com/Interbotix/interbotix_ros_toolboxes/blob/main/interbotix_xs_toolbox/interbotix_xs_modules/src/interbotix_xs_modules/arm.py
@@ -46,6 +45,8 @@ class ViperXInterface(ManipulatorInterface):
         self._side_img = np.array((480, 640, 3), dtype=np.uint8)
         self._wrist_img = np.array((480, 640, 3), dtype=np.uint8)
         self.blocking_control = blocking_control
+        # start persistent image fetching thread to avoid latency issues
+        img_primary_thread = self.start_img_fetch_thread()
 
     @property
     def primary_img(self) -> np.ndarray:

--- a/manipulator_gym/interfaces/widowx.py
+++ b/manipulator_gym/interfaces/widowx.py
@@ -12,7 +12,6 @@ from interbotix_xs_modules.arm import InterbotixManipulatorXS
 
 ##############################################################################
 
-
 class WidowXInterface(ViperXInterface):
     """
     https://github.com/Interbotix/interbotix_ros_toolboxes/blob/main/interbotix_xs_toolbox/interbotix_xs_modules/src/interbotix_xs_modules/arm.py
@@ -49,6 +48,8 @@ class WidowXInterface(ViperXInterface):
         self._side_img = np.array((480, 640, 3), dtype=np.uint8)
         self._wrist_img = np.array((480, 640, 3), dtype=np.uint8)
         self.blocking_control = blocking_control
+        # start persistent image fetching thread to avoid latency issues
+        img_primary_thread = self.start_img_fetch_thread()
 
     @property
     def primary_img(self) -> np.ndarray:

--- a/manipulator_gym/interfaces/widowx.py
+++ b/manipulator_gym/interfaces/widowx.py
@@ -44,15 +44,14 @@ class WidowXInterface(ViperXInterface):
             self._caps = []
             for id in cam_ids:
                 self._caps.append(cv2.VideoCapture(id))
-
         self._side_img = np.array((480, 640, 3), dtype=np.uint8)
         self._wrist_img = np.array((480, 640, 3), dtype=np.uint8)
+        self.fetch_primary_img()
         self.blocking_control = blocking_control
         # start persistent image fetching thread to avoid latency issues
         img_primary_thread = self.start_img_fetch_thread()
-
-    @property
-    def primary_img(self) -> np.ndarray:
+    
+    def fetch_primary_img(self) -> None:
         if self._caps is None:
             return self._side_img
         else:
@@ -60,7 +59,11 @@ class WidowXInterface(ViperXInterface):
             # If frame is read correctly ret is True
             if not ret:
                 raise Exception("Can't receive frame (stream end?). Exiting ...")
-            return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            self.primary_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+    @property
+    def primary_img(self) -> np.ndarray:
+        return self.primary_frame
 
     @property
     def wrist_img(self):

--- a/manipulator_gym/interfaces/widowx_ros2.py
+++ b/manipulator_gym/interfaces/widowx_ros2.py
@@ -32,6 +32,9 @@ class WidowXRos2Interface(ManipulatorInterface):
             )  # Initialize the VideoCapture object
         assert len(self._caps) <= 2, "Only 2 cameras are supported"
         self.blocking_control = blocking_control
+        # start persistent image fetching thread to avoid latency issues
+        img_primary_thread = self.start_img_fetch_thread()
+
 
     @property
     def primary_img(self) -> np.ndarray:

--- a/manipulator_gym/interfaces/widowx_ros2.py
+++ b/manipulator_gym/interfaces/widowx_ros2.py
@@ -35,25 +35,22 @@ class WidowXRos2Interface(ManipulatorInterface):
         # start persistent image fetching thread to avoid latency issues
         img_primary_thread = self.start_img_fetch_thread()
 
-
-    @property
-    def primary_img(self) -> np.ndarray:
+    def fetch_primary_img(self) -> None:
         ret, frame = self._caps[0].read()
         # If frame is read correctly ret is True
         if not ret:
             raise Exception("Can't receive frame (stream end?). Exiting ...")
-        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        self._primary_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
-    @property
-    def wrist_img(self):
+    def fetch_wrist_img(self) -> None:
         if len(self._caps) < 2:
-            return None
-
-        ret, frame = self._caps[1].read()
-        # If frame is read correctly ret is True
-        if not ret:
-            raise Exception("Can't receive frame (stream end?). Exiting ...")
-        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            self._wrist_frame = None
+        else:
+            ret, frame = self._caps[1].read()
+            # If frame is read correctly ret is True
+            if not ret:
+                raise Exception("Can't receive frame (stream end?). Exiting ...")
+            self._wrist_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
     @property
     def eef_pose(self) -> np.ndarray:

--- a/manipulator_gym/interfaces/widowx_sim.py
+++ b/manipulator_gym/interfaces/widowx_sim.py
@@ -106,8 +106,7 @@ class WidowXSimInterface:
             grip_state.append(abs(p.getJointState(self.arm, joint_id)[0]))
         return 1.0 if sum(grip_state) > 0.05 else 0.0
 
-    @property
-    def primary_img(self) -> np.ndarray:
+    def fetch_primary_img(self) -> None:
         """return the image from the camera"""
         # Obtain the camera image
         img_arr = p.getCameraImage(
@@ -121,29 +120,27 @@ class WidowXSimInterface:
         img_arr = img_arr[:, :, :3]
         img_arr = np.array(img_arr, dtype=np.uint8)
         # img_arr = cv2.cvtColor(img_arr, cv2.COLOR_BGR2RGB)
-        return img_arr
+        self._primary_frame = img_arr
 
-    @property
-    def wrist_img(self, return_blank: bool = True) -> Optional[np.ndarray]:
+    def fetch_wrist_img(self, return_blank: bool = True) -> None:
         """
         Return the image from the wrist camera. Default blank image
         """
         if return_blank:
             """default return blank img"""
-            return np.zeros((self.image_size[0], self.image_size[1], 3), dtype=np.uint8)
-
-        # NOTE: experimental feature to use wrist camera
-        img_arr = p.getCameraImage(
-            height=self.image_size[0],
-            width=self.image_size[1],
-            viewMatrix=self._compute_wrist_cam_view_matrix(),
-            projectionMatrix=self.cam_proj_matrix,
-            renderer=p.ER_BULLET_HARDWARE_OPENGL,  # Use hardware acceleration
-        )[2]
-        img_arr = img_arr[:, :, :3]
-        img_arr = np.array(img_arr, dtype=np.uint8)
-        return img_arr
-        # return None
+            self._wrist_frame = np.zeros((self.image_size[0], self.image_size[1], 3), dtype=np.uint8)
+        else:
+            # NOTE: experimental feature to use wrist camera
+            img_arr = p.getCameraImage(
+                height=self.image_size[0],
+                width=self.image_size[1],
+                viewMatrix=self._compute_wrist_cam_view_matrix(),
+                projectionMatrix=self.cam_proj_matrix,
+                renderer=p.ER_BULLET_HARDWARE_OPENGL,  # Use hardware acceleration
+            )[2]
+            img_arr = img_arr[:, :, :3]
+            img_arr = np.array(img_arr, dtype=np.uint8)
+            self._wrist_frame = img_arr
 
     def step_action(self, action: np.ndarray) -> bool:
         """

--- a/manipulator_gym/interfaces/widowx_sim.py
+++ b/manipulator_gym/interfaces/widowx_sim.py
@@ -106,6 +106,18 @@ class WidowXSimInterface:
             grip_state.append(abs(p.getJointState(self.arm, joint_id)[0]))
         return 1.0 if sum(grip_state) > 0.05 else 0.0
 
+    @property
+    def primary_img(self) -> np.ndarray:
+        """return the image from the camera"""
+        return self._primary_frame
+
+    @property
+    def wrist_img(self) -> Optional[np.ndarray]:
+        """
+        return the image from the wrist camera
+        """
+        return self._wrist_frame
+    
     def fetch_primary_img(self) -> None:
         """return the image from the camera"""
         # Obtain the camera image

--- a/policies/vla_eval.py
+++ b/policies/vla_eval.py
@@ -16,7 +16,7 @@ import threading
 
 from manipulator_gym.manipulator_env import ManipulatorEnv
 from manipulator_gym.interfaces.interface_service import ActionClientInterface
-from manipulator_gym.utils.gym_wrappers import ClipActionBoxBoundary
+from manipulator_gym.utils.gym_wrappers import ClipActionBoxBoundary, ConvertState2Proprio, ResizeObsImageWrapper
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string("ip", "localhost", "IP address of the robot server.")
@@ -49,6 +49,10 @@ def main(_):
     # NOTE: using the kitchen sink setup boundary of https://github.com/simpler-env/SimplerEnv
     env = ClipActionBoxBoundary(
         env, workspace_boundary=[[-float('inf'), -float('inf'), -float('inf')], [float('inf'), float('inf'), float('inf')]]
+    )
+    env = ConvertState2Proprio(env)
+    env = ResizeObsImageWrapper(
+        env, resize_size={"image_primary": (256, 256)}
     )
 
     # Load Processor & VLA
@@ -97,7 +101,7 @@ def main(_):
 
     # format the prompt
     prompt = f"In: What action should the robot take to {FLAGS.text_cond}?\nOut:"
-
+    print(prompt)
     def run_continuous_img_primary(manipulator_interface):
         """Continuously run manipulator_interface.img_primary in a loop."""
         while True:
@@ -118,48 +122,52 @@ def main(_):
     img_primary_thread = start_img_primary_thread(interface)
 
     # running rollouts
-    for _ in range(100):
-        obs, info = env.reset()
-        episode_return = 0.0
-        for i in range(100):
-            start_time = time.time()
+    try:
+        for _ in range(100):
+            obs, info = env.reset()
+            episode_return = 0.0
+            for i in range(100):
+                start_time = time.time()
 
-            image = obs["image_primary"]
-            image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)  # convert to RGB
+                image = obs["image_primary"]
+                image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)  # convert to RGB
 
-            if FLAGS.show_img:
-                cv2.imshow("image", image)
-                # capture "r" key and reset
-                if cv2.waitKey(10) & 0xFF == ord("r"):
+                if FLAGS.show_img:
+                    cv2.imshow("image", image)
+                    # capture "r" key and reset
+                    if cv2.waitKey(10) & 0xFF == ord("r"):
+                        break
+
+                image_cond = Image.fromarray(image)
+                inputs = processor(prompt, image_cond).to(device, dtype=torch.bfloat16)
+
+                # Predict Action (7-DoF; un-normalize for BridgeData V2)
+                action = vla.predict_action(
+                    **inputs, unnorm_key=unnorm_key, do_sample=False
+                )
+                assert (
+                    len(action) == 7
+                ), f"Action size should be in x, y, z, rx, ry, rz, gripper"
+
+                print("--- VLA inference took %s seconds ---" % (time.time() - start_time))
+                print(f" Step {i}: performing action: {action}")
+
+                if FLAGS.clip_actions:
+                    action[:6] = np.clip(action[:6], -0.02, 0.02)
+                    print(f"Clipped action: {action}")
+
+                # step env -- info contains full "chunk" of observations for logging
+                # obs only contains observation for final step of chunk
+                obs, reward, done, trunc, info = env.step(action)
+                episode_return += reward
+
+                if done:
                     break
 
-            image_cond = Image.fromarray(image)
-            inputs = processor(prompt, image_cond).to(device, dtype=torch.bfloat16)
-
-            # Predict Action (7-DoF; un-normalize for BridgeData V2)
-            action = vla.predict_action(
-                **inputs, unnorm_key=unnorm_key, do_sample=False
-            )
-            assert (
-                len(action) == 7
-            ), f"Action size should be in x, y, z, rx, ry, rz, gripper"
-
-            print("--- VLA inference took %s seconds ---" % (time.time() - start_time))
-            print(f" Step {i}: performing action: {action}")
-
-            if FLAGS.clip_actions:
-                action[:6] = np.clip(action[:6], -0.02, 0.02)
-                print(f"Clipped action: {action}")
-
-            # step env -- info contains full "chunk" of observations for logging
-            # obs only contains observation for final step of chunk
-            obs, reward, done, trunc, info = env.step(action)
-            episode_return += reward
-
-            if done:
-                break
-
-        print(f"Episode return: {episode_return}")
+            print(f"Episode return: {episode_return}")
+    except KeyboardInterrupt:
+        env.reset()
+        quit()
 
 
 if __name__ == "__main__":

--- a/policies/vla_eval.py
+++ b/policies/vla_eval.py
@@ -12,7 +12,6 @@ import peft
 import numpy as np
 from absl import app, flags, logging
 import cv2
-import threading
 
 from manipulator_gym.manipulator_env import ManipulatorEnv
 from manipulator_gym.interfaces.interface_service import ActionClientInterface
@@ -102,24 +101,6 @@ def main(_):
     # format the prompt
     prompt = f"In: What action should the robot take to {FLAGS.text_cond}?\nOut:"
     print(prompt)
-    def run_continuous_img_primary(manipulator_interface):
-        """Continuously run manipulator_interface.img_primary in a loop."""
-        while True:
-            try:
-                _ = manipulator_interface.primary_img
-            except Exception as e:
-                print(f"Error in continuous img_primary thread: {e}")
-                break
-    def start_img_primary_thread(manipulator_interface):
-        """Start a thread that continuously runs img_primary."""
-        img_primary_thread = threading.Thread(
-            target=run_continuous_img_primary,
-            args=(manipulator_interface,),
-            daemon=True  # This ensures the thread will be terminated when the main program exits
-        )
-        img_primary_thread.start()
-        return img_primary_thread
-    img_primary_thread = start_img_primary_thread(interface)
 
     # running rollouts
     try:


### PR DESCRIPTION
As a result of the fix proposed in PR #20, a data race condition emerged where multiple sources attempting to retrieve the image frame resource from `primary_img ` (more specifically, the calls to `cv2.VideoCapture(id).read()`) caused failed retrievals, which were interpreted as fatal bugs on the server-side and resulted in immature stream exits. Both the persistent image fetching thread spawned in `start_img_fetch_thread` from `ManipulatorInterface` and the observation call on the client side caused this data race.

To fix this data race, this PR confines the access to the VideoCapture stream to _only_ the persistent image fetching thread. The `primary_img` property accessed by the client now only accesses the (now private) field that retains the most recent image fetched by the persistent thread. The same logic applies to `wrist_img`. Future robot configurations will instead overwrite `fetch_primary_img` and `fetch_wrist_img`, where `primary_img` and `wrist_img` will remain properties that only access a private field.

The viperx interface does not use cv2 to fetch images and instead relies on ROS; therefore, we do not propagate this change to the viperx interface (since no python-side image fetching occurs.) Any latency issues that may arise on viperx will be a result of slowness on ROS-side, and has been noted in the documentation to alert future users.